### PR TITLE
Add support for Laravel 12.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "filament/filament": "^3.0",
         "laravel/jetstream": "^4.2|^5.0",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Problem
---
- The package is not compatible with Laravel 12. The package `laravel/framework:12` requires `illuminate/contracts:12` but `stephenjude/filament-jetstream` fix the version to `^10.0|^11.0`.

## Solution
- Allow illuminate/contracts:12 to be installed as valid dependency.

## Tests
- I extensively checked the package after the update in a Laravel 12 app. Everything works smooth.