### PR TITLE
Guide for installing and configuring existing Laravel applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,15 @@ class User extends Authenticatable implements  HasAvatar, HasPasskeys
 Add the following to your default panel plugin configuration:
 
 ```php
-use Filament\Jetstream\JetstreamPlugin;use Illuminate\Validation\Rules\Password;
+use \App\Models\User;
+use Filament\Jetstream\JetstreamPlugin;
+use Illuminate\Validation\Rules\Password;
+
 ...
 ->plugins([
     ...
     JetstreamPlugin::make()
-        ->configureUserModel(userModel: \App\Models\User::class)
+        ->configureUserModel(userModel: User::class)
         ->profilePhoto(condition: fn() => true, disk: 'public')
         ->deleteAccount(condition: fn() => true)
         ->updatePassword(condition: fn() => true, Password::default())
@@ -121,8 +124,9 @@ php artisan vendor:publish --tag=filament-jetstream-team-migration
 Update `App\Models\User` model to implement 'Filament\Models\Contracts\HasTenants' and use `Filament\Jetstream\HasTeams` trait.
 
 ```php
-use Filament\Models\Contracts\HasTenants;
+...
 use Filament\Jetstream\HasTeams;
+use Filament\Models\Contracts\HasTenants;
 
 class User extends Authenticatable implements  HasTenants
 {
@@ -136,17 +140,18 @@ class User extends Authenticatable implements  HasTenants
 Add the following to your default panel plugin configuration:
 
 ```php
+use \Filament\Jetstream\Role;
 use Filament\Jetstream\JetstreamPlugin;
 use Illuminate\Validation\Rules\Password;
-use \Filament\Jetstream\Role;
 use \Filament\Jetstream\Models\{Team,Membership,TeamInvitation};
+
 ...
 ->plugins([
     ...
     JetstreamPlugin::make()
         ->teams(
             condition: fn() => Feature::active('teams'), 
-            acceptTeamInvitation: fn($invitationId) => TeamInvitation::find($invitationId)->accept() // write your logic here
+            acceptTeamInvitation: fn($invitationId) => JetstreamPlugin::make()->defaultAcceptTeamInvitation()
         )
         ->configureTeamModels(
             teamModel: Team::class,
@@ -167,8 +172,6 @@ php artisan vendor:publish --tag=filament-jetstream-team-migration
 #### Add api feature trait to User model
 Update `App\Models\User` model to  use `Laravel\Sanctum\HasApiTokens` trait.
 ```php
-
-
 use Filament\Models\Contracts\HasTenants;
 use Filament\Jetstream\HasTeams;
 
@@ -187,6 +190,7 @@ use Filament\Jetstream\JetstreamPlugin;
 use Illuminate\Validation\Rules\Password;
 use \Filament\Jetstream\Role;
 use \Filament\Jetstream\Models\{Team, Membership, TeamInvitation};
+
 ...
 ->plugins([
     ...

--- a/README.md
+++ b/README.md
@@ -40,54 +40,9 @@ You can remove the `--teams` and `--api` arguments if you don't want those featu
 
 ##### 🌍 Translation-ready
 
-## Existing Laravel projects
+## Usage & Configurations
 
-### Installing the Profile feature
-
-#### Publish profile migrations
-Run the following command to publish the profile migrations.
-
-```bash
-php artisan vendor:publish --tag=filament-jetstream-migrations --tag=passkeys-migrations --tag=filament-two-factor-authentication-migrations
-```
-
-#### Add profile feature traits to the User model
-Update the `App\Models\User` model:
-
-```php
-...
-use Filament\Jetstream\HasProfilePhoto;
-use Filament\Models\Contracts\HasAvatar;
-use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
-use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticatable;
-
-class User extends Authenticatable implements  HasAvatar, HasPasskeys
-{
-    ...
-    use HasProfilePhoto; 
-    use TwoFactorAuthenticatable; 
-
-    protected $hidden = [
-        ...
-        'two_factor_recovery_codes',
-        'two_factor_secret',
-    ];
-
-    protected $appends = [
-        ...
-        'profile_photo_url',
-    ];
-
-    public function getFilamentAvatarUrl(): ?string
-    {
-        return $this->profile_photo_url;
-    }
-}
-```
-
-#### Configure the profile features 
-Add the following to your default panel plugin configuration:
-
+#### Configuring the User Profile
 ```php
 use \App\Models\User;
 use Filament\Jetstream\JetstreamPlugin;
@@ -112,32 +67,7 @@ use Illuminate\Validation\Rules\Password;
 ])
 ```
 
-### Installing the Team Features
-
-#### Publish team migration
-Run the following command to publish the **team** migrations.
-```bash
-php artisan vendor:publish --tag=filament-jetstream-team-migration
-```
-
-#### Add team feature traits to User model
-Update `App\Models\User` model to implement 'Filament\Models\Contracts\HasTenants' and use `Filament\Jetstream\HasTeams` trait.
-
-```php
-...
-use Filament\Jetstream\HasTeams;
-use Filament\Models\Contracts\HasTenants;
-
-class User extends Authenticatable implements  HasTenants
-{
-    ...
-    use HasTeams;
-}
-
-```
-
-#### Configure the team features
-Add the following to your default panel plugin configuration:
+#### Configuring Team features
 
 ```php
 use \Filament\Jetstream\Role;
@@ -162,29 +92,7 @@ use \Filament\Jetstream\Models\{Team,Membership,TeamInvitation};
 ])
 ```
 
-### Installing the API Features
-#### Publish team migration
-Run the following command to publish the **team** migrations.
-```bash
-php artisan vendor:publish --tag=filament-jetstream-team-migration
-```
-
-#### Add api feature trait to User model
-Update `App\Models\User` model to  use `Laravel\Sanctum\HasApiTokens` trait.
-```php
-use Filament\Models\Contracts\HasTenants;
-use Filament\Jetstream\HasTeams;
-
-class User extends Authenticatable implements  HasTenants
-{
-    use HasTeams;
-}
-
-```
-
-#### Configure the API features
-Add the following to your default panel plugin configuration:
-
+#### Configuring API features
 ```php
 use Filament\Jetstream\JetstreamPlugin;
 use Illuminate\Validation\Rules\Password;
@@ -204,6 +112,93 @@ use \Filament\Jetstream\Models\{Team, Membership, TeamInvitation};
 ])
 ```
 
+## Existing Laravel projects
+
+### Installing the Profile feature
+
+#### Publish profile migrations
+Run the following command to publish the profile migrations.
+
+```bash
+php artisan vendor:publish \
+  --tag=filament-jetstream-migrations \
+  --tag=passkeys-migrations \
+  --tag=filament-two-factor-authentication-migrations
+```
+
+#### Add profile feature traits to the User model
+Update the `App\Models\User` model:
+
+```php
+...
+use Filament\Jetstream\HasProfilePhoto;
+use Filament\Models\Contracts\HasAvatar;
+use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
+use \Filament\Jetstream\InteractsWIthProfile;
+
+class User extends Authenticatable implements  HasAvatar, HasPasskeys
+{
+    ...
+    use InteractsWIthProfile;
+
+    protected $hidden = [
+        ...
+        'two_factor_recovery_codes',
+        'two_factor_secret',
+    ];
+
+    protected $appends = [
+        ...
+        'profile_photo_url',
+    ];
+}
+```
+
+
+
+### Installing the Team Features
+
+#### Publish team migration
+Run the following command to publish the **team** migrations.
+```bash
+php artisan vendor:publish --tag=filament-jetstream-team-migration
+```
+
+#### Add team feature traits to User model
+Update `App\Models\User` model to implement 'Filament\Models\Contracts\HasTenants' and use `Filament\Jetstream\InteractsWithTeams` trait.
+
+```php
+...
+use Filament\Jetstream\InteractsWithTeams;
+use Filament\Models\Contracts\HasTenants;
+
+class User extends Authenticatable implements  HasTenants
+{
+    ...
+    use InteractsWithTeams;
+}
+
+```
+
+### Installing the API Features
+#### Publish team migration
+Run the following command to publish the **team** migrations.
+```bash
+php artisan vendor:publish --tag=filament-jetstream-team-migration
+```
+
+#### Add api feature trait to User model
+Update `App\Models\User` model to  use `Laravel\Sanctum\HasApiTokens` trait.
+```php
+...
+use \Laravel\Sanctum\HasApiTokens;
+
+class User extends Authenticatable 
+{
+    use HasApiTokens;
+}
+
+```
 
 ## Testing
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -73,7 +73,6 @@ class InstallCommand extends Command
             // Factories
             copy(__DIR__ . '/../../database/factories/TeamFactory.php', base_path('database/factories/TeamFactory.php'));
 
-
             $this->replaceInFile(
                 '// use Filament\Models\Contracts\HasTenants;',
                 'use Filament\Models\Contracts\HasTenants;',

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -92,8 +92,8 @@ class InstallCommand extends Command
             );
 
             $this->replaceInFile(
-                '// use HasTeams;',
-                'use HasTeams;',
+                '// use InteractsWithTeams;',
+                'use InteractsWithTeams;',
                 app_path('Models/User.php')
             );
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -73,19 +73,22 @@ class InstallCommand extends Command
             // Factories
             copy(__DIR__ . '/../../database/factories/TeamFactory.php', base_path('database/factories/TeamFactory.php'));
 
-            // Implement \Filament\Models\Contracts\HasTenants contract in User Model
+
             $this->replaceInFile(
                 '// use Filament\Models\Contracts\HasTenants;',
                 'use Filament\Models\Contracts\HasTenants;',
                 app_path('Models/User.php')
             );
 
-            $this->replaceInFile(', MustVerifyEmail', ', MustVerifyEmail, HasTenants', app_path('Models/User.php'));
-
-            // Add \Filament\Jetstream\HasTeams trait to User Model
             $this->replaceInFile(
-                '// use Filament\Jetstream\HasTeams',
-                'use Filament\Jetstream\HasTeams',
+                '// use Filament\Jetstream\InteractsWithTeams',
+                'use Filament\Jetstream\InteractsWithTeams',
+                app_path('Models/User.php')
+            );
+
+            $this->replaceInFile(
+                ', MustVerifyEmail',
+                ', MustVerifyEmail, HasTenants',
                 app_path('Models/User.php')
             );
 
@@ -99,7 +102,8 @@ class InstallCommand extends Command
             $this->replaceInFile(
                 '->twoFactorAuthentication()',
                 '->twoFactorAuthentication()
-                    ->teams()',
+                 ->teams()
+                 ',
                 app_path('Providers/Filament/AppPanelProvider.php')
             );
         }
@@ -123,7 +127,8 @@ class InstallCommand extends Command
             $this->replaceInFile(
                 '->twoFactorAuthentication()',
                 '->twoFactorAuthentication()
-                    ->apiTokens()',
+                 ->apiTokens()
+                 ',
                 app_path('Providers/Filament/AppPanelProvider.php')
             );
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -68,7 +68,7 @@ class InstallCommand extends Command
 
         // Setup Team
         if ($this->option('teams')) {
-            $this->call('vendor:publish', ['--tag' => 'filament-jetstream-team-migrations', '--force' => true]);
+            $this->call('vendor:publish', ['--tag' => 'filament-jetstream-team-migrations']);
 
             // Factories
             copy(__DIR__ . '/../../database/factories/TeamFactory.php', base_path('database/factories/TeamFactory.php'));

--- a/src/InteractsWIthProfile.php
+++ b/src/InteractsWIthProfile.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Jetstream;
 
+use Filament\Panel;
 use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticatable;
 
 trait InteractsWIthProfile
@@ -12,5 +13,10 @@ trait InteractsWIthProfile
     public function getFilamentAvatarUrl(): ?string
     {
         return $this->profile_photo_url;
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
     }
 }

--- a/src/InteractsWIthProfile.php
+++ b/src/InteractsWIthProfile.php
@@ -2,18 +2,12 @@
 
 namespace Filament\Jetstream;
 
-use Filament\Jetstream\Models\Team;
-use Filament\Panel;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
-use Laravel\Sanctum\HasApiTokens;
 use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticatable;
 
 trait InteractsWIthProfile
 {
-    use TwoFactorAuthenticatable;
     use HasProfilePhoto;
+    use TwoFactorAuthenticatable;
 
     public function getFilamentAvatarUrl(): ?string
     {

--- a/src/InteractsWIthProfile.php
+++ b/src/InteractsWIthProfile.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Jetstream;
+
+use Filament\Jetstream\Models\Team;
+use Filament\Panel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\HasApiTokens;
+use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticatable;
+
+trait InteractsWIthProfile
+{
+    use TwoFactorAuthenticatable;
+    use HasProfilePhoto;
+
+    public function getFilamentAvatarUrl(): ?string
+    {
+        return $this->profile_photo_url;
+    }
+}

--- a/src/InteractsWithTeams.php
+++ b/src/InteractsWithTeams.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Filament\Jetstream;
+
+trait InteractsWithTeams
+{
+    use HasTeams;
+}

--- a/src/Pages/Auth/Register.php
+++ b/src/Pages/Auth/Register.php
@@ -13,7 +13,7 @@ class Register extends \Filament\Auth\Pages\Register
 
         if (Filament::hasTenancy()) {
             $user->switchTeam($user->ownedTeams()->create([
-                'name' => "$user->name's Team",
+                'name' => 'My Workspace',
                 'personal_team' => true,
             ]));
         }

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -5,12 +5,12 @@ namespace App\Models;
 use Filament\Jetstream\InteractsWIthProfile;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasAvatar;
-use Filament\Panel;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
+
 // use Filament\Models\Contracts\HasTenants;
 // use Filament\Jetstream\InteractsWithTeams;
 // use Laravel\Sanctum\HasApiTokens;

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -2,15 +2,15 @@
 
 namespace App\Models;
 
-use Filament\Panel;
-use Illuminate\Notifications\Notifiable;
-use Filament\Models\Contracts\HasAvatar;
-use Filament\Models\Contracts\FilamentUser;
 use Filament\Jetstream\InteractsWIthProfile;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Models\Contracts\HasAvatar;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
 use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
+
 // use Filament\Models\Contracts\HasTenants;
 // use Filament\Jetstream\InteractsWithTeams;
 // use Laravel\Sanctum\HasApiTokens;
@@ -18,8 +18,8 @@ use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
 class User extends Authenticatable implements FilamentUser, HasAvatar, HasPasskeys, MustVerifyEmail
 {
     use HasFactory;
-    use Notifiable;
     use InteractsWIthProfile;
+    use Notifiable;
     // use InteractsWithTeams;
     // use HasApiTokens;
 

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -2,30 +2,26 @@
 
 namespace App\Models;
 
-use Filament\Jetstream\HasProfilePhoto;
-use Filament\Models\Contracts\FilamentUser;
-use Filament\Models\Contracts\HasAvatar;
 use Filament\Panel;
+use Illuminate\Notifications\Notifiable;
+use Filament\Models\Contracts\HasAvatar;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Jetstream\InteractsWIthProfile;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Notifications\Notifiable;
 use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
-use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticatable;
-
 // use Filament\Models\Contracts\HasTenants;
+// use Filament\Jetstream\InteractsWithTeams;
 // use Laravel\Sanctum\HasApiTokens;
-// use Filament\Jetstream\HasTeams;
 
 class User extends Authenticatable implements FilamentUser, HasAvatar, HasPasskeys, MustVerifyEmail
 {
     use HasFactory;
-    use HasProfilePhoto;
     use Notifiable;
-    use TwoFactorAuthenticatable;
-
+    use InteractsWIthProfile;
+    // use InteractsWithTeams;
     // use HasApiTokens;
-    // use HasTeams;
 
     /**
      * The attributes that are mass assignable.
@@ -67,16 +63,6 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasPasske
     protected $appends = [
         'profile_photo_url',
     ];
-
-    public function canAccessPanel(Panel $panel): bool
-    {
-        return true;
-    }
-
-    public function getFilamentAvatarUrl(): ?string
-    {
-        return $this->profile_photo_url;
-    }
 
     /**
      * Get the attributes that should be cast.

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -5,12 +5,12 @@ namespace App\Models;
 use Filament\Jetstream\InteractsWIthProfile;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasAvatar;
+use Filament\Panel;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
-
 // use Filament\Models\Contracts\HasTenants;
 // use Filament\Jetstream\InteractsWithTeams;
 // use Laravel\Sanctum\HasApiTokens;

--- a/stubs/app/Providers/AppPanelProvider.php
+++ b/stubs/app/Providers/AppPanelProvider.php
@@ -27,7 +27,6 @@ class AppPanelProvider extends PanelProvider
             ->default()
             ->id('app')
             ->path('/')
-            ->homeUrl('/dashboard')
             ->colors(['primary' => Color::Gray])
             ->brandLogo('https://laravel.com/img/logomark.min.svg')
             ->brandLogoHeight('40px')


### PR DESCRIPTION
# Description
This PR improves documentation and developer experience for integrating Filament Jetstream into existing Laravel apps, and introduces small quality-of-life changes.

### [Docs] Rework README for existing apps

- Replaced/streamlined “Existing Laravel projects” with clear “Usage & Configurations” plus step-by-step install sections.
- Corrected plugin API usage and method signatures.
- Updated teams/API setup examples and clarified default invitation handling.

### [DX] New helper traits for User model
- Added Filament\Jetstream\InteractsWIthProfile to bundle `HasProfilePhoto`, `TwoFactorAuthenticatable` traits.
- Added Filament\Jetstream\InteractsWithTeams to bundle team-related behavior via HasTeams.
- stubs/app/Models/User.php to use these traits for quicker scaffolding.

### [UX] 
- Tweak default team name in `Filament\Jetstream\Pages\Auth\Register`, default personal team name is now “My Workspace”.