### PR TITLE
Update php version in  phpstan.yml

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies


### PR DESCRIPTION
Hi I noticed that your PHPStan was failing because the php version was too low.
Made a small PR to fix it by using the 8.3 version. Wasn't sure if you wanted to have this workflow to use the matrix so kept it simple.