### PR TITLE
Fixing an incorrect translation of the “Password” section in a UI

### DIFF
--- a/src/Livewire/Profile/UpdatePassword.php
+++ b/src/Livewire/Profile/UpdatePassword.php
@@ -33,7 +33,7 @@ class UpdatePassword extends BaseLivewireComponent
             ->schema([
                 Section::make(__('filament-jetstream::default.update_profile_information.section.title'))
                     ->aside()
-                    ->description(__('filament-jetstream::default.update_profile_information.section.description'))
+                    ->description(__('filament-jetstream::default.update_password.section.description'))
                     ->schema([
                         TextInput::make('currentPassword')
                             ->label(__('filament-jetstream::default.form.current_password.label'))


### PR DESCRIPTION
Fixes #54 