### PR TITLE
Add avatar support and update related fields in user and team models

### DIFF
--- a/database/migrations/2025_08_22_134103_add_profile_photo_column_to_users_table.php
+++ b/database/migrations/2025_08_22_134103_add_profile_photo_column_to_users_table.php
@@ -4,15 +4,14 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('profile_photo_path', 2048)->nullable()->after('email_verified_at');
+            $table->string('avatar', 2048)->nullable()->after('email_verified_at');
         });
     }
 
@@ -21,6 +20,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropColumns('users', 'profile_photo_path');
+        Schema::dropColumns('users', 'avatar');
     }
 };

--- a/database/migrations/2025_08_22_134103_create_teams_table.php
+++ b/database/migrations/2025_08_22_134103_create_teams_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -19,6 +18,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->index();
             $table->string('name');
+            $table->string('slug')->unique();
             $table->boolean('personal_team');
             $table->timestamps();
         });
@@ -50,11 +50,17 @@ return new class extends Migration
     public function down(): void
     {
         Schema::disableForeignKeyConstraints();
-        Schema::dropColumns('users', 'current_team_id');
-        Schema::enableForeignKeyConstraints();
 
-        Schema::dropIfExists('teams');
-        Schema::dropIfExists('team_user');
+        // Drop dependent tables first
         Schema::dropIfExists('team_invitations');
+        Schema::dropIfExists('team_user');
+        Schema::dropIfExists('teams');
+
+        // Finally drop column from users
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('current_team_id');
+        });
+
+        Schema::enableForeignKeyConstraints();
     }
 };

--- a/src/Concerns/HasTeamsFeatures.php
+++ b/src/Concerns/HasTeamsFeatures.php
@@ -28,20 +28,22 @@ trait HasTeamsFeatures
 
     public string $teamInvitationModel = TeamInvitation::class;
 
-    public Closure | bool $hasTeamFeature = false;
+    public Closure|bool $hasTeamFeature = false;
 
     public ?Closure $acceptTeamInvitation = null;
+    public string $tenantSlug = 'slug';
 
     public function hasTeamsFeatures(): bool
     {
         return $this->evaluate($this->hasTeamFeature) === true;
     }
 
-    public function teams(Closure | bool $condition = true, ?Closure $acceptTeamInvitation = null): static
+    public function teams(Closure|bool $condition = true, ?Closure $acceptTeamInvitation = null, string $tenantSlug = 'slug'): static
     {
         $this->hasTeamFeature = $condition;
 
         $this->acceptTeamInvitation = $acceptTeamInvitation;
+        $this->tenantSlug = $tenantSlug;
 
         return $this;
     }
@@ -57,7 +59,7 @@ trait HasTeamsFeatures
     public function teamsRoutes(): array
     {
         return [
-            Route::get('/team-invitations/{invitation}', fn ($invitation) => $this->acceptTeamInvitation === null
+            Route::get('/team-invitations/{invitation}', fn($invitation) => $this->acceptTeamInvitation === null
                 ? $this->defaultAcceptTeamInvitation($invitation)
                 : $this->evaluate($this->acceptTeamInvitation, ['invitationId' => $invitation]))
                 ->middleware(['signed'])
@@ -86,6 +88,10 @@ trait HasTeamsFeatures
     {
         return $this->teamModel;
     }
+    public function tenantSlug(): string
+    {
+        return $this->tenantSlug;
+    }
 
     public function membershipModel(): string
     {
@@ -102,7 +108,7 @@ trait HasTeamsFeatures
         return $this->roleModel;
     }
 
-    public function defaultAcceptTeamInvitation(string | int $invitationId): RedirectResponse
+    public function defaultAcceptTeamInvitation(string|int $invitationId): RedirectResponse
     {
         $model = Jetstream::plugin()->teamInvitationModel();
 

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -12,8 +12,8 @@ trait HasProfilePhoto
      */
     public function updateProfilePhoto(string $photo): void
     {
-        tap($this->profile_photo_path, function ($previous) use ($photo) {
-            $this->forceFill(['profile_photo_path' => $photo])->save();
+        tap($this->avatar, function ($previous) use ($photo) {
+            $this->forceFill(['avatar' => $photo])->save();
 
             if ($previous) {
                 Storage::disk($this->profilePhotoDisk())->delete($previous);
@@ -26,18 +26,18 @@ trait HasProfilePhoto
      */
     public function deleteProfilePhoto(): void
     {
-        if (! Jetstream::plugin()?->managesProfilePhotos()) {
+        if (!Jetstream::plugin()?->managesProfilePhotos()) {
             return;
         }
 
-        if (is_null($this->profile_photo_path)) {
+        if (is_null($this->avatar)) {
             return;
         }
 
-        Storage::disk($this->profilePhotoDisk())->delete($this->profile_photo_path);
+        Storage::disk($this->profilePhotoDisk())->delete($this->avatar);
 
         $this->forceFill([
-            'profile_photo_path' => null,
+            'avatar' => null,
         ])->save();
     }
 
@@ -47,8 +47,8 @@ trait HasProfilePhoto
     public function profilePhotoUrl(): Attribute
     {
         return Attribute::get(function (): string {
-            return $this->profile_photo_path
-                ? Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path)
+            return $this->avatar
+                ? Storage::disk($this->profilePhotoDisk())->url($this->avatar)
                 : $this->defaultProfilePhotoUrl();
         });
     }

--- a/src/InteractsWIthProfile.php
+++ b/src/InteractsWIthProfile.php
@@ -12,7 +12,7 @@ trait InteractsWIthProfile
 
     public function getFilamentAvatarUrl(): ?string
     {
-        return $this->profile_photo_url;
+        return $this->avatar;
     }
 
     public function canAccessPanel(Panel $panel): bool

--- a/src/JetstreamPlugin.php
+++ b/src/JetstreamPlugin.php
@@ -47,14 +47,14 @@ class JetstreamPlugin implements Plugin
     public function register(Panel $panel): void
     {
         $panel
-            ->homeUrl(fn () => str(filament()->getCurrentOrDefaultPanel()->getUrl())->append('/dashboard'))
+            ->homeUrl(fn() => str(filament()->getCurrentOrDefaultPanel()->getUrl())->append('/dashboard'))
             ->profile(EditProfile::class)
             ->plugins([
                 TwoFactorAuthenticationPlugin::make()
-                    ->enableTwoFactorAuthentication(condition: fn () => $this->enabledTwoFactorAuthetication())
-                    ->enablePasskeyAuthentication(condition: fn () => $this->enabledPasskeyAuthetication())
+                    ->enableTwoFactorAuthentication(condition: fn() => $this->enabledTwoFactorAuthetication())
+                    ->enablePasskeyAuthentication(condition: fn() => $this->enabledPasskeyAuthetication())
                     ->forceTwoFactorSetup(
-                        condition: fn () => $this->forceTwoFactorAuthetication(),
+                        condition: fn() => $this->forceTwoFactorAuthetication(),
                         requiresPassword: $this->requiresPasswordForAuthenticationSetup()
                     ),
             ]);
@@ -68,10 +68,10 @@ class JetstreamPlugin implements Plugin
         if ($this->hasTeamsFeatures()) {
             $panel
                 ->registration(Register::class)
-                ->tenant($this->teamModel())
+                ->tenant($this->teamModel(), $this->tenantSlug())
                 ->tenantRegistration(CreateTeam::class)
                 ->tenantProfile(EditTeam::class)
-                ->routes(fn () => $this->teamsRoutes());
+                ->routes(fn() => $this->teamsRoutes());
         }
     }
 

--- a/src/Livewire/ApiTokens/ManageApiTokens.php
+++ b/src/Livewire/ApiTokens/ManageApiTokens.php
@@ -21,7 +21,7 @@ class ManageApiTokens extends BaseLivewireComponent implements HasTable
     public function table(Table $table): Table
     {
         return $table
-            ->query(fn () => $this->authUser()->tokens()->latest())
+            ->query(fn() => $this->authUser()->tokens()->latest())
             ->columns([
                 Tables\Columns\Layout\Split::make([
                     Tables\Columns\TextColumn::make('name'),
@@ -36,18 +36,18 @@ class ManageApiTokens extends BaseLivewireComponent implements HasTable
                     ->modalCancelAction(false)
                     ->modalFooterActionsAlignment(Alignment::End)
                     ->modalSubmitActionLabel(__('filament-jetstream::default.action.update_token.modal.label'))
-                    ->schema(fn (PersonalAccessToken $record, Schema $schema) => $schema->schema(fn () => collect(Jetstream::plugin()?->getApiTokenPermissions())
-                        ->map(fn ($permission) => Checkbox::make($permission)->label(__($permission))->default($record->can($permission)))
+                    ->schema(fn(PersonalAccessToken $record, Schema $schema) => $schema->schema(fn() => collect(Jetstream::plugin()?->getApiTokenPermissions())
+                        ->map(fn($permission) => Checkbox::make($permission)->label(__($permission))->default($record->can($permission)))
                         ->toArray())
                         ->columns())
-                    ->action(fn ($record, array $data) => $this->updateToken($record, $data)),
+                    ->action(fn($record, array $data) => $this->updateToken($record, $data)),
                 Action::make('deleteToken')
                     ->color('danger')
                     ->modalWidth('md')
                     ->label(__('filament-jetstream::default.action.delete_token.label'))
                     ->modalHeading(__('filament-jetstream::default.action.delete_token.title'))
                     ->modalDescription(__('filament-jetstream::default.action.delete_token.description'))
-                    ->action(fn ($record) => $this->deleteToken($record)),
+                    ->action(fn($record) => $this->deleteToken($record)),
             ]);
     }
 
@@ -64,7 +64,7 @@ class ManageApiTokens extends BaseLivewireComponent implements HasTable
     {
         $record->delete();
 
-        $this->sendNotification(__('filament-jetstream::default.notification.token_deleted.success'));
+        $this->sendNotification(__('filament-jetstream::default.notification.token_deleted.success.message'));
     }
 
     public function render()

--- a/src/Livewire/Profile/UpdateProfileInformation.php
+++ b/src/Livewire/Profile/UpdateProfileInformation.php
@@ -32,16 +32,17 @@ class UpdateProfileInformation extends BaseLivewireComponent
                 Section::make(__('filament-jetstream::default.update_profile_information.section.title'))
                     ->aside()
                     ->description(__('filament-jetstream::default.update_profile_information.section.description'))
-                    ->schema([FileUpload::make('profile_photo_path')
-                        ->label(__('filament-jetstream::default.form.profile_photo.label'))
-                        ->avatar()
-                        ->image()
-                        ->imageEditor()
-                        ->visibility('public')
-                        ->directory('profile-photos')
-                        ->formatStateUsing(fn () => filament()->auth()->user()?->profile_photo_path)
-                        ->disk(fn (): string => Jetstream::plugin()?->profilePhotoDisk())
-                        ->visible(fn (): bool => Jetstream::plugin()?->managesProfilePhotos()),
+                    ->schema([
+                        FileUpload::make('avatar')
+                            ->label(__('filament-jetstream::default.form.profile_photo.label'))
+                            ->avatar()
+                            ->image()
+                            ->imageEditor()
+                            ->visibility('public')
+                            ->directory('avatars')
+                            ->formatStateUsing(fn() => filament()->auth()->user()?->avatar)
+                            ->disk(fn(): string => Jetstream::plugin()?->profilePhotoDisk())
+                            ->visible(fn(): bool => Jetstream::plugin()?->managesProfilePhotos()),
                         TextInput::make('name')
                             ->label(__('filament-jetstream::default.form.name.label'))
                             ->string()
@@ -78,9 +79,9 @@ class UpdateProfileInformation extends BaseLivewireComponent
 
         $isUpdatingEmail = $data['email'] !== $user->email;
 
-        $isUpdatingPhoto = $data['profile_photo_path'] !== $user->profile_photo_path;
+        $isUpdatingPhoto = $data['avatar'] !== $user->avatar;
 
-        $user->forceFill(Arr::except($data, ['profile_photo_path']))->save();
+        $user->forceFill(Arr::except($data, ['avatar']))->save();
 
         if ($isUpdatingEmail) {
             $user->forceFill(['email_verified_at' => null]);
@@ -89,8 +90,8 @@ class UpdateProfileInformation extends BaseLivewireComponent
         }
 
         if ($isUpdatingPhoto) {
-            Arr::get($data, 'profile_photo_path')
-                ? $user->updateProfilePhoto($data['profile_photo_path'])
+            Arr::get($data, 'avatar')
+                ? $user->updateProfilePhoto($data['avatar'])
                 : $user->deleteProfilePhoto();
         }
 

--- a/src/Models/Team.php
+++ b/src/Models/Team.php
@@ -21,6 +21,7 @@ class Team extends Model
      */
     protected $fillable = [
         'name',
+        'slug',
         'personal_team',
     ];
 
@@ -45,6 +46,13 @@ class Team extends Model
         return [
             'personal_team' => 'boolean',
         ];
+    }
+
+    protected static function booted()
+    {
+        static::creating(function (Team $team) {
+            $team->slug = \Str::slug($team->name);
+        });
     }
 
     /**

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -6,7 +6,7 @@ class Dashboard extends \Filament\Pages\Dashboard
 {
     protected static string $routePath = '/dashboard';
 
-    public function getColumns(): int | array
+    public function getColumns(): int|array
     {
         return 1;
     }

--- a/src/Pages/EditProfile.php
+++ b/src/Pages/EditProfile.php
@@ -7,7 +7,7 @@ use Filament\Jetstream\Jetstream;
 
 class EditProfile extends \Filament\Auth\Pages\EditProfile
 {
-    protected static string | null | \BackedEnum $navigationIcon = 'heroicon-o-user-circle';
+    protected static string|null|\BackedEnum $navigationIcon = 'heroicon-o-user-circle';
 
     protected string $view = 'filament-jetstream::pages.edit-profile';
 
@@ -18,7 +18,7 @@ class EditProfile extends \Filament\Auth\Pages\EditProfile
         parent::mount();
 
         if ($id = $this->getUser()?->currentTeam?->id) {
-            once(fn () => Filament::setTenant(Jetstream::plugin()->teamModel::find($id)));
+            once(fn() => Filament::setTenant(Jetstream::plugin()->teamModel::find($id)));
         }
     }
 

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -61,7 +61,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasPasske
      * @var array<int, string>
      */
     protected $appends = [
-        'profile_photo_url',
+        'avatar',
     ];
 
     /**
@@ -75,5 +75,10 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasPasske
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function getAvatarAttribute()
+    {
+        return $this->attributes['avatar'];
     }
 }


### PR DESCRIPTION
- Introduced 'avatar' field in the users table and updated related methods.
- Changed 'profile_photo_path' to 'avatar' in relevant classes and migrations.
- Added 'slug' field to teams and ensured it is generated from the team name.
- Fixed migration issues when rollback
- Added tenant slug supports by default 'slug' it can change using 'tenantSlug' parameters in teams()
- Updated various components to reflect the new avatar functionality.