### PR TITLE
fix the agent error

### DIFF
--- a/src/Livewire/Profile/LogoutOtherBrowserSessions.php
+++ b/src/Livewire/Profile/LogoutOtherBrowserSessions.php
@@ -98,7 +98,7 @@ class LogoutOtherBrowserSessions extends BaseLivewireComponent
             ->orderBy('last_activity', 'desc')
             ->get()->map(function ($session) {
                 return (object) [
-                    'agent' => tap(new Agent, fn ($agent) => $session->user_agent),
+                    'agent' => tap(new Agent, fn($agent) => $agent->setUserAgent($session->user_agent)),
                     'ip_address' => $session->ip_address,
                     'is_current_device' => $session->id === request()->session()->getId(),
                     'last_active' => Carbon::createFromTimestamp($session->last_activity)->diffForHumans(),


### PR DESCRIPTION
**Title**: Fix agent error for browser sessions

**Description**:
This PR resolves issue #58 by fixing the browser session agent error in `src/Livewire/Profile/LogoutOtherBrowserSessions.php`, ensuring the `Agent` class correctly processes the `user_agent` string by updating the initialization to use `setUserAgent`.

**Changes**:
- Updated `Agent` initialization in `LogoutOtherBrowserSessions.php`.

**Testing**:
- Verified browser session data displays correctly.

Closes #58.