### PR TITLE
Improved Filament-Team Sections to not show repeated title and description

### DIFF
--- a/src/Livewire/Teams/AddTeamMember.php
+++ b/src/Livewire/Teams/AddTeamMember.php
@@ -40,64 +40,59 @@ class AddTeamMember extends BaseLivewireComponent
         return $schema
             ->statePath('data')
             ->schema([
-                Section::make(__('filament-jetstream::default.add_team_member.section.title'))
-                    ->aside()
-                    ->visible(fn () => Gate::check('addTeamMember', $this->team))
-                    ->description(__('filament-jetstream::default.add_team_member.section.description'))
-                    ->schema([
-                        TextEntry::make('addTeamMemberNotice')
-                            ->hiddenLabel()
-                            ->state(fn () => __('filament-jetstream::default.add_team_member.section.notice')),
-                        TextInput::make('email')
-                            ->label(__('filament-jetstream::default.form.email.label'))
-                            ->email()
-                            ->required()
-                            ->unique(table: Jetstream::plugin()->teamInvitationModel(), modifyRuleUsing: function (
-                                Unique $rule
-                            ) {
-                                return $rule->where(
-                                    Jetstream::getForeignKeyColumn(Jetstream::plugin()->teamModel()),
-                                    $this->team->id
-                                );
-                            })
-                            ->validationMessages([
-                                'unique' => __(
-                                    'filament-jetstream::default.action.add_team_member.error_message.email_already_invited'
-                                ),
-                            ])
-                            ->rules([
-                                fn (): Closure => function (string $attribute, $value, Closure $fail) {
-                                    if ($this->team->hasUserWithEmail($value)) {
-                                        $fail(
-                                            __(
-                                                'filament-jetstream::default.action.add_team_member.error_message.email_already_invited'
-                                            )
-                                        );
-                                    }
-                                },
-                            ]),
-                        Grid::make()
-                            ->columns(1)
-                            ->schema(function () {
-                                $roles = collect(Jetstream::plugin()?->getTeamRolesAndPermissions());
 
-                                return [
-                                    Radio::make('role')
-                                        ->hiddenLabel()
-                                        ->required()
-                                        ->in($roles->pluck('key'))
-                                        ->options($roles->pluck('name', 'key'))
-                                        ->descriptions($roles->pluck('description', 'key')),
-                                ];
-                            }),
-                        Actions::make([
-                            Action::make('addTeamMember')
-                                ->label(__('filament-jetstream::default.action.add_team_member.label'))
-                                ->action(function () {
-                                    $this->addTeamMember($this->team);
-                                }),
-                        ])->alignEnd(),
+                TextEntry::make('addTeamMemberNotice')
+                    ->hiddenLabel()
+                    ->state(fn() => __('filament-jetstream::default.add_team_member.section.notice')),
+                TextInput::make('email')
+                    ->label(__('filament-jetstream::default.form.email.label'))
+                    ->email()
+                    ->required()
+                    ->unique(table: Jetstream::plugin()->teamInvitationModel(), modifyRuleUsing: function (
+                        Unique $rule
+                    ) {
+                        return $rule->where(
+                            Jetstream::getForeignKeyColumn(Jetstream::plugin()->teamModel()),
+                            $this->team->id
+                        );
+                    })
+                    ->validationMessages([
+                        'unique' => __(
+                            'filament-jetstream::default.action.add_team_member.error_message.email_already_invited'
+                        ),
+                    ])
+                    ->rules([
+                        fn(): Closure => function (string $attribute, $value, Closure $fail) {
+                            if ($this->team->hasUserWithEmail($value)) {
+                                $fail(
+                                    __(
+                                        'filament-jetstream::default.action.add_team_member.error_message.email_already_invited'
+                                    )
+                                );
+                            }
+                        },
                     ]),
+                Grid::make()
+                    ->columns(1)
+                    ->schema(function () {
+                        $roles = collect(Jetstream::plugin()?->getTeamRolesAndPermissions());
+
+                        return [
+                            Radio::make('role')
+                                ->hiddenLabel()
+                                ->required()
+                                ->in($roles->pluck('key'))
+                                ->options($roles->pluck('name', 'key'))
+                                ->descriptions($roles->pluck('description', 'key')),
+                        ];
+                    }),
+                Actions::make([
+                    Action::make('addTeamMember')
+                        ->label(__('filament-jetstream::default.action.add_team_member.label'))
+                        ->action(function () {
+                            $this->addTeamMember($this->team);
+                        }),
+                ])->alignEnd(),
             ]);
     }
 

--- a/src/Livewire/Teams/AddTeamMember.php
+++ b/src/Livewire/Teams/AddTeamMember.php
@@ -40,7 +40,6 @@ class AddTeamMember extends BaseLivewireComponent
         return $schema
             ->statePath('data')
             ->schema([
-
                 TextEntry::make('addTeamMemberNotice')
                     ->hiddenLabel()
                     ->state(fn() => __('filament-jetstream::default.add_team_member.section.notice')),

--- a/src/Livewire/Teams/DeleteTeam.php
+++ b/src/Livewire/Teams/DeleteTeam.php
@@ -26,26 +26,20 @@ class DeleteTeam extends BaseLivewireComponent
     {
         return $schema
             ->schema([
-                Section::make(__('filament-jetstream::default.delete_team.section.title'))
-                    ->description(__('filament-jetstream::default.delete_team.section.description'))
-                    ->aside()
-                    ->visible(fn () => Gate::check('delete', $this->team))
-                    ->schema([
-                        TextEntry::make('notice')
-                            ->hiddenLabel()
-                            ->state(__('filament-jetstream::default.delete_team.section.notice')),
-                        Actions::make([
-                            Action::make('deleteAccountAction')
-                                ->label(__('filament-jetstream::default.action.delete_team.label'))
-                                ->color('danger')
-                                ->requiresConfirmation()
-                                ->modalHeading(__('filament-jetstream::default.delete_team.section.title'))
-                                ->modalDescription(__('filament-jetstream::default.action.delete_team.notice'))
-                                ->modalSubmitActionLabel(__('filament-jetstream::default.action.delete_team.label'))
-                                ->modalCancelAction(false)
-                                ->action(fn () => $this->deleteTeam($this->team)),
-                        ]),
-                    ]),
+                TextEntry::make('notice')
+                    ->hiddenLabel()
+                    ->state(__('filament-jetstream::default.delete_team.section.notice')),
+                Actions::make([
+                    Action::make('deleteAccountAction')
+                        ->label(__('filament-jetstream::default.action.delete_team.label'))
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->modalHeading(__('filament-jetstream::default.delete_team.section.title'))
+                        ->modalDescription(__('filament-jetstream::default.action.delete_team.notice'))
+                        ->modalSubmitActionLabel(__('filament-jetstream::default.action.delete_team.label'))
+                        ->modalCancelAction(false)
+                        ->action(fn() => $this->deleteTeam($this->team)),
+                ]),
             ]);
     }
 

--- a/src/Livewire/Teams/UpdateTeamName.php
+++ b/src/Livewire/Teams/UpdateTeamName.php
@@ -28,21 +28,16 @@ class UpdateTeamName extends BaseLivewireComponent
     {
         return $schema
             ->schema([
-                Section::make(__('filament-jetstream::default.update_team_name.section.title'))
-                    ->aside()
-                    ->description(__('filament-jetstream::default.update_team_name.section.description'))
-                    ->schema([
-                        TextInput::make('name')
-                            ->label(__('filament-jetstream::default.form.team_name.label'))
-                            ->string()
-                            ->maxLength(255)
-                            ->required(),
-                        Actions::make([
-                            Action::make('save')
-                                ->label(__('filament-jetstream::default.action.save.label'))
-                                ->action(fn () => $this->updateTeamName($this->team)),
-                        ])->alignEnd(),
-                    ]),
+                TextInput::make('name')
+                    ->label(__('filament-jetstream::default.form.team_name.label'))
+                    ->string()
+                    ->maxLength(255)
+                    ->required(),
+                Actions::make([
+                    Action::make('save')
+                        ->label(__('filament-jetstream::default.action.save.label'))
+                        ->action(fn() => $this->updateTeamName($this->team)),
+                ])->alignEnd(),
             ])
             ->statePath('data');
     }


### PR DESCRIPTION
Sorry, after further troubleshooting I found the Sections repeated and was able to remove repetition by deleting the section in Livewire since it is being loaded in view as well.

Before:
<img width="1256" height="709" alt="Team_Handling" src="https://github.com/user-attachments/assets/a82b61bb-cef6-48b3-81a5-1e1767dad5a8" />

After:
<img width="848" height="921" alt="image" src="https://github.com/user-attachments/assets/aa1d2a6b-ca41-4a91-ab14-4324cbb6c76d" />

