### PR TITLE
Fix migration issues and auto-generate slugs for existing teams to ensure backward compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,11 @@
     },
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
+        "post-update-cmd": [
+            "@php artisan vendor:publish --tag=filament-jetstream-team-slug-migrations --force",
+            "@php artisan optimize",
+            "@php artisan migrate"
+        ],
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",

--- a/database/migrations/2025_08_22_134103_create_teams_table.php
+++ b/database/migrations/2025_08_22_134103_create_teams_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -50,11 +49,18 @@ return new class extends Migration
     public function down(): void
     {
         Schema::disableForeignKeyConstraints();
-        Schema::dropColumns('users', 'current_team_id');
-        Schema::enableForeignKeyConstraints();
 
-        Schema::dropIfExists('teams');
-        Schema::dropIfExists('team_user');
+        // Drop dependent tables first
         Schema::dropIfExists('team_invitations');
+        Schema::dropIfExists('team_user');
+        Schema::dropIfExists('teams');
+
+        // Finally drop column from users
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('current_team_id');
+        });
+
+        Schema::enableForeignKeyConstraints();
     }
+
 };

--- a/database/migrations/2025_10_01_165811_add_slug_column_in_teams_table.php
+++ b/database/migrations/2025_10_01_165811_add_slug_column_in_teams_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Filament\Jetstream\Models\Team;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            if (!Schema::hasColumn('teams', 'slug')) {
+                $table->string('slug')->nullable()->after('name');
+            }
+        });
+
+        // Auto-generate slug for existing teams (Seeder will loop through teams in the DB)
+        Team::whereNull('slug')->chunk(100, function ($teams) {
+            foreach ($teams as $team) {
+                $baseSlug = Str::slug($team->name);
+                $slug = $baseSlug;
+                $counter = 1;
+
+                // check until slug is unique
+                while (
+                    Team::where('slug', $slug)
+                        ->where('id', '!=', $team->id) // excluding the current team being processed
+                        ->exists()
+                ) {
+                    $slug = $baseSlug . '-' . $counter;
+                    $counter++;
+                }
+
+                $team->slug = $slug;
+                $team->save();
+            }
+        });
+
+        // Add a unique index to the 'slug' column to prevent duplicate values.
+        Schema::table('teams', function (Blueprint $table) {
+            $table->unique('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropUnique(['slug']);
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -146,6 +146,9 @@ class InstallCommand extends Command
         // Publish 2FA migrations
         $this->call('vendor:publish', ['--tag' => 'filament-two-factor-authentication-migrations']);
 
+        // Publish jetstream team slug migration
+        $this->call('vendor:publish', ['--tag' => 'filament-jetstream-team-slug-migrations']);
+
         // Link local storage
         $this->call('storage:link');
 

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -47,6 +47,12 @@ class JetstreamServiceProvider extends PackageServiceProvider
         $this->publishes([
             __DIR__ . '/../database/migrations/2025_08_22_134103_create_teams_table.php' => database_path('migrations/2025_08_22_134103_create_teams_table.php'),
         ], 'filament-jetstream-team-migrations');
+
+        $this->publishes([
+            __DIR__ . '/../database/migrations/2025_10_01_165811_add_slug_column_in_teams_table.php'
+            => database_path('migrations/2025_10_01_165811_add_slug_column_in_teams_table.php'),
+        ], 'filament-jetstream-team-slug-migrations');
+
     }
 
     public function packageBooted()


### PR DESCRIPTION
### This PR addresses migration issues that occur on existing installations.

- Ensures the slug column is added only if it doesn’t already exist.
- Prevents migration failure when upgrading from older versions.
- Keeps backward compatibility with existing databases.
- Automatically generates slugs for existing team records to ensure smooth upgrades.

**After updating the package, please run the following command to publish the new migration:**
`
php artisan vendor:publish --tag=filament-jetstream-team-slug-migrations
`
`
php artisan migrate
`

This PR does not introduce any new features, it only fixes the migration to make upgrades safe.