### PR TITLE
Fixed DeleteAccount and enhanced deprecated modal form

### DIFF
--- a/src/Livewire/Profile/DeleteAccount.php
+++ b/src/Livewire/Profile/DeleteAccount.php
@@ -7,11 +7,13 @@ use Filament\Forms;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Jetstream\Jetstream;
 use Filament\Jetstream\Livewire\BaseLivewireComponent;
+use Filament\Jetstream\Models\Team;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
@@ -27,7 +29,7 @@ class DeleteAccount extends BaseLivewireComponent
                     ->schema([
                         TextEntry::make('deleteAccountNotice')
                             ->hiddenLabel()
-                            ->state(fn () => __('filament-jetstream::default.delete_account.section.notice')),
+                            ->state(fn() => __('filament-jetstream::default.delete_account.section.notice')),
                         Actions::make([
                             Action::make('deleteAccount')
                                 ->label(__('filament-jetstream::default.action.delete_account.label'))
@@ -37,7 +39,7 @@ class DeleteAccount extends BaseLivewireComponent
                                 ->modalDescription(__('filament-jetstream::default.action.delete_account.notice'))
                                 ->modalSubmitActionLabel(__('filament-jetstream::default.action.delete_account.label'))
                                 ->modalCancelAction(false)
-                                ->form([
+                                ->schema([
                                     Forms\Components\TextInput::make('password')
                                         ->password()
                                         ->revealable()
@@ -45,9 +47,12 @@ class DeleteAccount extends BaseLivewireComponent
                                         ->required()
                                         ->currentPassword(),
                                 ])
-                                ->action(fn (array $data) => $this->deleteAccount()),
+                                ->action(fn(array $data) => $this->deleteAccount())
+                                ->successNotificationTitle('User deleted')
+                                ->successRedirectUrl('/HealthcareProvider'),
                         ]),
-                    ])]);
+                    ])
+            ]);
     }
 
     /**
@@ -62,7 +67,7 @@ class DeleteAccount extends BaseLivewireComponent
                 $user->teams()->detach();
 
                 $user->ownedTeams->each(function (Team $team) {
-                    $this->deletesTeams->delete($team);
+                    $team->delete();
                 });
             }
 
@@ -73,7 +78,7 @@ class DeleteAccount extends BaseLivewireComponent
             $user->delete();
         });
 
-        filament()->auth()->logout();
+        Auth::logout();
 
         return redirect(filament()->getLoginUrl());
     }


### PR DESCRIPTION
On Delete account it showed the following error:

`Filament\Jetstream\Livewire\Profile\DeleteAccount::{closure:{closure:Filament\Jetstream\Livewire\Profile\DeleteAccount::deleteAccount():61}:65}(): Argument #1 ($team) must be of type Filament\Jetstream\Livewire\Profile\Team, Filament\Jetstream\Models\Team given, called in /.../vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php on line 271`

Fixed above error.

Enhanced form within modal to follow Filament v4 schema structure instead of deprecated form.

Enhanced redirect as well after action success submission, with Notification.