### PR TITLE
chore(phpstan): update configuration to use supported methods only

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,3 @@ parameters:
         - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
-    checkModelProperties: true
-    checkMissingIterableValueType: false
-


### PR DESCRIPTION
Some methods were deprecated in newer versions:
[(https://github.com/phpstan/phpstan/issues/7557)]