### PR TITLE
chore(phpstan): replace PHPStan with Larastan for enhanced built-in features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstanlarastan/larastan": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,41 @@
 includes:
-    - phpstan-baseline.neon
+    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/nesbot/carbon/extension.neon
 
 parameters:
     level: 4
+
     paths:
         - src
-        - config
-        - database
+        - database/factories
+        - database/seeders
+
     tmpDir: build/phpstan
-    checkOctaneCompatibility: true
+
+    # Recommended for Laravel packages
+    checkModelProperties: true
+    checkModelRelations: true
+    checkMissingTemplateVars: false # package usually has no Blade templates
+    checkImplicitMixed: true
+    analyseModelFactoryBuilders: true
+
+    # Optional performance tweak
+    parallel:
+        maximumNumberOfProcesses: 4
+
+    # Avoid vendor false positives
+    scanDirectories:
+        - vendor
+
+    # Skip non-source dirs
+    excludePaths:
+        - tests/CreatesApplication.php
+        - bootstrap/*
+        - storage/*
+        - node_modules/*
+
+    # Ignore known dynamic or generated code
+    ignoreErrors:
+        - '#Call to an undefined method Illuminate\\.*#'
+        - '#Call to an undefined method Filament\\.*#'
+        - '#Access to an undefined property Livewire\\.*#'


### PR DESCRIPTION
`checkOctaneCompatibility: true`
was removed in newer versions of PHPStan-Laravel (around v1.3+).
It used to come from the nunomaduro/larastan extension.
Now, Octane compatibility is checked automatically by Larastan when relevant — no need to explicitly enable it.