### PR TITLE
Enhanced Avatar Generation with Context-Aware Naming

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -58,8 +58,11 @@ trait HasProfilePhoto
      */
     protected function defaultProfilePhotoUrl(): string
     {
+        // Use getFilamentName() if available for context-aware naming, otherwise fall back to name
+        $displayName = method_exists($this, 'getFilamentName') ? $this->getFilamentName() : $this->name;
+
         $name = trim(
-            collect(explode(' ', $this->name))->map(function ($segment) {
+            collect(explode(' ', $displayName))->map(function ($segment) {
                 return mb_substr($segment, 0, 1);
             })->join(' ')
         );


### PR DESCRIPTION
#### Enhanced
- **Context-aware avatar generation** - Default profile photo avatars now use `getFilamentName()` method when available, ensuring avatar initials match the context-aware display names shown throughout the Filament UI
- Avatar generation now respects custom naming logic (e.g., "Mr. John Doe", "Ms. Jane Doe") instead of using only the raw `name` column
- Falls back gracefully to `$this->name` if `getFilamentName()` method doesn't exist, maintaining backward compatibility

#### Technical Details
- `HasProfilePhoto::defaultProfilePhotoUrl()` now checks for `getFilamentName()` method before generating avatar initials
- Avatar initials are generated from the full context-aware name (including titles/prefixes)
- Maintains compatibility with models that don't implement `getFilamentName()`

#### Benefits
- **Consistency** - Avatar initials now match the display names shown in Filament UI
- **Context-Aware** - Supports applications with custom naming logic (e.g., gender-based titles, role-based prefixes)
- **Backward Compatible** - Works seamlessly with existing implementations
- **Better UX** - Users see consistent naming across all UI elements

#### Example
For a user with `getFilamentName()` returning "Mr. John Doe":
- **Before:** Avatar shows initials "JD" (from `name` column: "John Doe")
- **After:** Avatar shows initials "MJD" (from context-aware name: "Mr. John Doe")

This ensures the avatar reflects the same context-aware naming used throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced profile photo display name generation to better determine avatar initials and display information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->