### PR TITLE
fix: update registerRoutes to be compatible with Filament v4.8.0

### DIFF
--- a/src/Pages/ApiTokens.php
+++ b/src/Pages/ApiTokens.php
@@ -3,7 +3,6 @@
 namespace Filament\Jetstream\Pages;
 
 use Filament\Pages\Page;
-use Filament\Pages\PageConfiguration;
 use Filament\Panel;
 use Illuminate\Support\Facades\Route;
 
@@ -26,7 +25,7 @@ class ApiTokens extends Page
         return 'tokens';
     }
 
-    public static function registerRoutes(Panel $panel, ?PageConfiguration $configuration = null): void
+    public static function registerRoutes(Panel $panel, $configuration = null): void
     {
         if (filled(static::getCluster())) {
             Route::name(static::prependClusterRouteBaseName($panel, ''))

--- a/src/Pages/ApiTokens.php
+++ b/src/Pages/ApiTokens.php
@@ -3,6 +3,7 @@
 namespace Filament\Jetstream\Pages;
 
 use Filament\Pages\Page;
+use Filament\Pages\PageConfiguration;
 use Filament\Panel;
 use Illuminate\Support\Facades\Route;
 
@@ -25,17 +26,17 @@ class ApiTokens extends Page
         return 'tokens';
     }
 
-    public static function registerRoutes(Panel $panel): void
+    public static function registerRoutes(Panel $panel, ?PageConfiguration $configuration = null): void
     {
         if (filled(static::getCluster())) {
             Route::name(static::prependClusterRouteBaseName($panel, ''))
                 ->prefix(static::prependClusterSlug($panel, ''))
-                ->group(fn () => static::routes($panel));
+                ->group(fn () => static::routes($panel, $configuration));
 
             return;
         }
 
-        static::routes($panel);
+        static::routes($panel, $configuration);
     }
 
     public static function getRouteName(string | Panel | null $panel = null): string

--- a/src/Pages/ApiTokens.php
+++ b/src/Pages/ApiTokens.php
@@ -27,15 +27,19 @@ class ApiTokens extends Page
 
     public static function registerRoutes(Panel $panel, $configuration = null): void
     {
+        $registerRoutes = fn () => $configuration === null 
+            ? static::routes($panel) 
+            : static::routes($panel, $configuration);
+        
         if (filled(static::getCluster())) {
             Route::name(static::prependClusterRouteBaseName($panel, ''))
                 ->prefix(static::prependClusterSlug($panel, ''))
-                ->group(fn () => static::routes($panel, $configuration));
+                ->group($registerRoutes);
 
             return;
         }
 
-        static::routes($panel, $configuration);
+        $registerRoutes();
     }
 
     public static function getRouteName(string | Panel | null $panel = null): string


### PR DESCRIPTION
Filament v4.8.0 introduced "Configurable resources", which updated the Page::registerRoutes() signature to include an optional PageConfiguration parameter:

  `registerRoutes(Panel $panel, ?PageConfiguration $configuration = null)`

ApiTokens::registerRoutes() was not updated to match, causing a PHP fatal error on autoload due to incompatible method signature inheritance.

- Added the missing optional `?PageConfiguration $configuration = null` parameter to restore compatibility with Filament v4.8.0+, and passed $configuration through to the internal static::routes() as well.

Fixes:

>   PHP Fatal error:  Declaration of Filament\Jetstream\Pages\ApiTokens::registerRoutes(Filament\Panel $panel): void must be compatible with Filament\Pages\Page::registerRoutes(Filament\Panel $panel, ?Filament\Pages\PageConfiguration $configuration = null): void

Ref: https://github.com/filamentphp/filament/releases/tag/v4.8.0
Ref: https://github.com/filamentphp/filament/pull/19225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Route registration now accepts an optional configuration parameter to enable more flexible internal routing.
  * Change is backward-compatible and affects internal handling only; there are no visible changes to the user interface or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->