### PR TITLE
Support Filament 5 and Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,4 +54,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,4 +54,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --no-coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - 2.x
   pull_request:
     branches:
       - main
+      - 2.x
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [12, 13]
+        laravel: ['12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 12.*
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -7,7 +7,7 @@ use Filament\Jetstream\Models\Team;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Filament\Jetstream\Models\Team>
+ * @extends Factory<Team>
  */
 class TeamFactory extends Factory
 {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -128,7 +128,7 @@ class Agent extends MobileDetect
     /**
      * Retrieve from the given key from the cache or resolve the value.
      *
-     * @param  \Closure():mixed  $callback
+     * @param  Closure():mixed  $callback
      * @return mixed
      */
     protected function retrieveUsingCacheOrResolve(string $key, Closure $callback)

--- a/src/Events/TeamEvent.php
+++ b/src/Events/TeamEvent.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Jetstream\Events;
 
+use App\Models\Team;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -15,14 +16,14 @@ abstract class TeamEvent
     /**
      * The team instance.
      *
-     * @var \App\Models\Team
+     * @var Team
      */
     public $team;
 
     /**
      * Create a new event instance.
      *
-     * @param  \App\Models\Team  $team
+     * @param  Team  $team
      * @return void
      */
     public function __construct($team)

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -5,6 +5,9 @@ namespace Filament\Jetstream;
 use Filament\Jetstream\Models\Team;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
@@ -25,7 +28,7 @@ trait HasTeams
     /**
      * Get the current team of the user's context.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function currentTeam()
     {
@@ -60,7 +63,7 @@ trait HasTeams
     /**
      * Get all of the teams the user owns or belongs to.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function allTeams()
     {
@@ -70,7 +73,7 @@ trait HasTeams
     /**
      * Get all of the teams the user owns.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function ownedTeams()
     {
@@ -80,7 +83,7 @@ trait HasTeams
     /**
      * Get all of the teams the user belongs to.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return BelongsToMany
      */
     public function teams()
     {
@@ -136,7 +139,7 @@ trait HasTeams
      * Get the role that the user has on the team.
      *
      * @param  mixed  $team
-     * @return \Filament\Jetstream\Role|null
+     * @return Role|null
      */
     public function teamRole($team)
     {

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -37,7 +37,6 @@ class JetstreamServiceProvider extends PackageServiceProvider
         $package->name(static::$name)
             ->hasViews()
             ->hasTranslations()
-            ->hasConfigFile(static::$name)
             ->hasCommands([InstallCommand::class]);
 
         $this->publishes([

--- a/src/Models/Team.php
+++ b/src/Models/Team.php
@@ -2,13 +2,17 @@
 
 namespace Filament\Jetstream\Models;
 
+use App\Models\User;
 use Filament\Jetstream\Events\TeamCreated;
 use Filament\Jetstream\Events\TeamDeleted;
 use Filament\Jetstream\Events\TeamUpdated;
 use Filament\Jetstream\Jetstream;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 
 class Team extends Model
 {
@@ -50,7 +54,7 @@ class Team extends Model
     /**
      * Get the owner of the team.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function owner()
     {
@@ -64,7 +68,7 @@ class Team extends Model
     /**
      * Get all of the team's users including its owner.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function allUsers()
     {
@@ -98,7 +102,7 @@ class Team extends Model
     /**
      * Determine if the given user belongs to the team.
      *
-     * @param  \App\Models\User  $user
+     * @param  User  $user
      * @return bool
      */
     public function hasUser($user)
@@ -121,7 +125,7 @@ class Team extends Model
     /**
      * Determine if the given user has the given permission on the team.
      *
-     * @param  \App\Models\User  $user
+     * @param  User  $user
      * @param  string  $permission
      * @return bool
      */
@@ -133,7 +137,7 @@ class Team extends Model
     /**
      * Get all of the pending user invitations for the team.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany
      */
     public function teamInvitations()
     {
@@ -145,7 +149,7 @@ class Team extends Model
     /**
      * Remove the given user from the team.
      *
-     * @param  \App\Models\User  $user
+     * @param  User  $user
      * @return void
      */
     public function removeUser($user)

--- a/src/Models/TeamInvitation.php
+++ b/src/Models/TeamInvitation.php
@@ -4,6 +4,7 @@ namespace Filament\Jetstream\Models;
 
 use Filament\Jetstream\Jetstream;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TeamInvitation extends Model
 {
@@ -20,7 +21,7 @@ class TeamInvitation extends Model
     /**
      * Get the team that the invitation belongs to.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function team()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,8 +10,7 @@ use Filament\Forms\FormsServiceProvider;
 use Filament\Infolists\InfolistsServiceProvider;
 use Filament\Jetstream\JetstreamServiceProvider;
 use Filament\Notifications\NotificationsServiceProvider;
-use Filament\SpatieLaravelSettingsPluginServiceProvider;
-use Filament\SpatieLaravelTranslatablePluginServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
@@ -43,8 +42,7 @@ class TestCase extends Orchestra
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
             NotificationsServiceProvider::class,
-            SpatieLaravelSettingsPluginServiceProvider::class,
-            SpatieLaravelTranslatablePluginServiceProvider::class,
+            SchemasServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,6 @@ use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -34,7 +33,6 @@ class TestCase extends Orchestra
     {
         return [
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             FilamentServiceProvider::class,


### PR DESCRIPTION
## Summary

- Test case referenced `Filament\SpatieLaravelSettingsPluginServiceProvider` and `Filament\SpatieLaravelTranslatablePluginServiceProvider`, both of which were extracted from `filament/filament` into separate optional packages. Replaced with `Filament\Schemas\SchemasServiceProvider`, which the package's Livewire components already depend on (via `Filament\Schemas\Schema` and `Filament\Schemas\Components\*`).
- Dropped the `hasConfigFile()` call from `JetstreamServiceProvider`. The `config/filament-jetstream.php` file was removed in 957e16a but the hook was left behind. Nothing in `src/` or `stubs/` reads from this config, and on older `spatie/laravel-package-tools` (< 1.30, which `prefer-lowest` resolves to) the missing file blew up `package:discover` and tests.
- Pointed CI at the new `2.x` branch.

Verified locally:

- `prefer-stable`: Filament 5.6.6 + Laravel 13.12.0 + `spatie/laravel-package-tools` 1.93.1, Pest passes.
- `prefer-lowest`: Filament 4.8.5 + Laravel 12.1.1 + `spatie/laravel-package-tools` 1.19.0, Pest passes.